### PR TITLE
use file.fsPath instead of file.path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,7 @@ export function activate(context: vscode.ExtensionContext) {
                 for (let _i = 0; _i < value.length; _i++) {
                     let file = value[_i];      
                     counter = counter.then(res => {
-                        return count(file.path, res)
+                        return count(file.fsPath, res)
                     })             
                 }
                 counter.then(result => {


### PR DESCRIPTION
Count workspace didn't work for me, at least on Windows. The same behavior was reported in [Q&A](https://marketplace.visualstudio.com/items?itemName=dollyn.line-counter#qna) by BleakDecember.

Seems like `fsPath` is a better option. It fixes the problem for me.